### PR TITLE
1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retter/rio-cli",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Retter.io Command Line Tool",
   "main": "./dist/index.js",
   "bin": {

--- a/src/commands/listProfiles.ts
+++ b/src/commands/listProfiles.ts
@@ -32,9 +32,9 @@ module.exports = {
         const ctx: TaskContext = await tasks.run()
 
         ConsoleMessage.table([
-            ["Profile Name", "Secret"],
+            ["Profile Name", "Secret", "Domain"],
             ...ctx.profiles.map(item => {
-                return [chalk.whiteBright(item.name), chalk.gray(item.secretId)]
+                return [chalk.whiteBright(item.name), chalk.gray(item.secretId),chalk.gray(item.domain || 'Not Configured')]
             })
         ], 'Profiles')
 

--- a/src/commands/setProfile.ts
+++ b/src/commands/setProfile.ts
@@ -11,7 +11,8 @@ interface Input extends GlobalInput {
     "profile-name": string,
     "secret-id": string,
     "secret-key": string,
-    "no-auth-dump": boolean
+    "no-auth-dump": boolean,
+    "domain": string
 }
 
 interface TaskContext {
@@ -22,7 +23,7 @@ module.exports = {
     command: 'set-profile',
     aliases: ['sp'],
     description: `Upsert admin profile in local storage
-    Usage: rio set-profile --profile-name PROFILE_NAME --secret-id SECRET_ID --secret-key SECRET_KEY
+    Usage: rio set-profile --profile-name PROFILE_NAME --secret-id SECRET_ID --secret-key SECRET_KEY --domain RIO_DOMAIN
     `,
     builder: yargs => {
         yargs.options('profile-name', {
@@ -33,6 +34,7 @@ module.exports = {
         yargs.options('secret-id', {describe: 'Secret Id', type: 'string', demandOption: true})
         yargs.options('secret-key', {describe: 'Secret Key', type: 'string', demandOption: true})
         yargs.options('no-auth-dump', {describe: 'Close authentication info', type: "boolean", default: false})
+        yargs.options('domain', { describe: 'URL to target rio console', type: 'string' })
         return yargs
     },
     handler: async (args) => {
@@ -45,7 +47,8 @@ module.exports = {
                         secretId: args["secret-id"],
                         secretKey: args["secret-key"],
                         profileName: args["profile-name"],
-                        noAuthDump: args["no-auth-dump"]
+                        noAuthDump: args["no-auth-dump"],
+                        domain: args["domain"]
                     })
                 }
             }

--- a/src/lib/Auth.ts
+++ b/src/lib/Auth.ts
@@ -1,14 +1,13 @@
 import jwt from "jsonwebtoken";
 import axios from "axios";
-import {CliConfig} from "./CliConfig";
+import {CliConfig, IRIOCliConfigProfileItemData} from "./CliConfig";
 import {RetterRootClasses, RetterRootMethods, RetterSdk} from "./RetterSdk";
 import {RIO_CLI_ROOT_PROJECT_ID} from "../config";
 
 
 export class Auth {
 
-    static async getRootAdminCustomToken(profile: string) {
-        const config = CliConfig.getAdminConfig(profile)
+    static async getRootAdminCustomToken(config: IRIOCliConfigProfileItemData) {
         const token = jwt.sign({
             projectId: RIO_CLI_ROOT_PROJECT_ID,
             secretId: config.secretId,
@@ -21,7 +20,7 @@ export class Auth {
                 value: config.secretId
             }
             const result = await axios({
-                url: RetterSdk.prepareRootUrlByKeyValue(RetterRootClasses.User, RetterRootMethods.generateAdminCustomToken, byKeyValue),
+                url: RetterSdk.prepareRootUrlByKeyValue(RetterRootClasses.User, RetterRootMethods.generateAdminCustomToken, byKeyValue, config.domain),
                 method: 'post',
                 data: {
                     "idToken": token

--- a/src/lib/CliConfig.ts
+++ b/src/lib/CliConfig.ts
@@ -12,6 +12,7 @@ export interface IRIOCliConfigProfileItemData {
     secretId: string;
     secretKey: string;
     noAuthDump: boolean;
+    domain?: string;
 }
 
 export interface IRIOCliConfig {
@@ -21,6 +22,7 @@ export interface IRIOCliConfig {
 export interface AdminProfileSummary {
     name: string
     secretId: string
+    domain?: string
 }
 
 export class CliConfig {
@@ -48,16 +50,18 @@ export class CliConfig {
             return {
                 name: key,
                 secretId: config.profiles[key].secretId,
+                domain: config.profiles[key].domain
             }
         })
     }
 
-    static upsertAdminProfile(props: { profileName: string, secretId: string, secretKey: string, noAuthDump: boolean }) {
+    static upsertAdminProfile(props: { profileName: string, secretId: string, secretKey: string, noAuthDump: boolean, domain?: string }) {
         const {
             profileName,
             secretId,
             secretKey,
-            noAuthDump
+            noAuthDump,
+            domain
         } = props
         if (!profileName || !secretId || !secretKey || noAuthDump === undefined)
             throw new Error('profile name, secret id and secret key are required')
@@ -67,7 +71,8 @@ export class CliConfig {
             cliConfig.profiles[profileName] = {
                 secretId,
                 secretKey,
-                noAuthDump
+                noAuthDump,
+                domain
             }
         } else {
             cliConfig = {
@@ -75,7 +80,8 @@ export class CliConfig {
                     [profileName]: {
                         secretKey,
                         secretId,
-                        noAuthDump
+                        noAuthDump,
+                        domain
                     }
                 }
             }
@@ -89,7 +95,7 @@ export class CliConfig {
             return {
                 noAuthDump: false,
                 secretKey: RIO_CLI_SECRET_KEY,
-                secretId: RIO_CLI_SECRET_ID
+                secretId: RIO_CLI_SECRET_ID,
             }
         }
         const profile = this.getCliConfig().profiles[profileName]

--- a/src/lib/ProjectManager.ts
+++ b/src/lib/ProjectManager.ts
@@ -37,11 +37,7 @@ export class ProjectManager {
         // generate new rio files
         await ProjectManager.generateAndSaveRioFiles()
 
-        const localModelContents = Project.getModelFileContents()
-        let localModels: IProjectModels = Object.keys(localModelContents).reduce<{ [modelName: string]: object }>((acc, modelName) => {
-            acc[modelName] = JSON.parse(localModelContents[modelName])
-            return acc
-        }, {})
+        let localModels: IProjectModels = Project.getModelsContents()
         const localClasses = Project.getLocalClassContents(classes)
 
         let remoteModels = project.detail.modelDefinitions
@@ -63,12 +59,10 @@ export class ProjectManager {
                 const template = Project.getLocalClassTemplate(className)
                 if (template.methods) {
                     template.methods.forEach(m => {
-
                         ProjectManager.models.forEach((model: string) => {
                             if (Object.prototype.hasOwnProperty.call(m, model)) {
                                 const modelName: string = (m as any)[model]
                                 selectedModels.push(modelName)
-                                Project.getModelDefs(modelName).forEach(d => selectedModels.push(d))
                             }
                         })
                     })
@@ -78,7 +72,6 @@ export class ProjectManager {
                         if (Object.prototype.hasOwnProperty.call(template.init, model)) {
                             const modelName: string = (template.init as any)[model]
                             selectedModels.push(modelName)
-                            Project.getModelDefs(modelName).forEach(d => selectedModels.push(d))
                         }
                     })
                 }
@@ -87,7 +80,6 @@ export class ProjectManager {
                         if (Object.prototype.hasOwnProperty.call(template.get, model)) {
                             const modelName: string = (template.get as any)[model]
                             selectedModels.push(modelName)
-                            Project.getModelDefs(modelName).forEach(d => selectedModels.push(d))
                         }
                     })
                 }
@@ -156,10 +148,7 @@ export class ProjectManager {
                 acc[className] = Project.readClassTemplateString(className)
                 return acc
             }, {}),
-            models: Project.listModelNames().reduce<{ [modelName: string]: string }>((acc, modelName) => {
-                acc[modelName] = JSON.parse(Project.readModelFile(modelName))
-                return acc
-            }, {})
+            models: Project.getModelsContents()
         })
     }
 

--- a/src/lib/RetterSdk.ts
+++ b/src/lib/RetterSdk.ts
@@ -2,6 +2,7 @@ import Retter, {RetterRegion} from "@retter/sdk";
 import {RIO_CLI_PLATFORM, RIO_CLI_ROOT_DOMAIN, RIO_CLI_ROOT_PROJECT_ID, RIO_CLI_STAGE, RIO_CLI_URL} from "../config";
 import {Auth} from "./Auth";
 import {RetterCloudObject, RetterCloudObjectCall, RetterCloudObjectConfig} from "@retter/sdk/dist/types";
+import {CliConfig} from "./CliConfig";
 
 
 export enum RetterRootClasses {
@@ -25,11 +26,16 @@ export class RetterSdk {
 
     private static retterRootSdk: Retter
 
-    static prepareRootUrlByKeyValue(classId: string, methodName: string, options: { key: string, value: string }) {
+    static prepareRootUrlByKeyValue(classId: string, methodName: string, options: { key: string, value: string }, domain?: string) {
         let url
-        if (RIO_CLI_URL) {
+        
+        if (domain) // GET URL FROM PROFILE
+        {
+            url = domain
+        }
+        else if (RIO_CLI_URL) { // GET URL FROM ENV
             url = RIO_CLI_URL
-        } else {
+        } else { // GET DEFAULT URL
             url = RIO_CLI_ROOT_DOMAIN
             if (RIO_CLI_STAGE === 'PROD') {
                 url = `${RIO_CLI_ROOT_PROJECT_ID}.api.${url}`
@@ -43,20 +49,22 @@ export class RetterSdk {
     static async getRootRetterSdkByAdminProfile(profile: string): Promise<Retter> {
         try {
             if (this.retterRootSdk) return this.retterRootSdk
+            const config = CliConfig.getAdminConfig(profile)
+
             const sdk = Retter.getInstance({
                 projectId: RIO_CLI_ROOT_PROJECT_ID,
-                url: RIO_CLI_URL,
+                url: config.domain || RIO_CLI_URL,
                 region: RIO_CLI_STAGE === 'PROD' ? RetterRegion.euWest1 : RetterRegion.euWest1Beta,
                 platform: RIO_CLI_PLATFORM,
                 logLevel: 'silent'
             })
 
-            const customAuth = await Auth.getRootAdminCustomToken(profile)
+            const customAuth = await Auth.getRootAdminCustomToken(config)
             await sdk.authenticateWithCustomToken(customAuth.customToken)
 
             this.retterRootSdk = sdk
             return sdk
-        } catch (e) {
+        } catch (e: any) {
             const customMessage = e.response && e.response.data ? (typeof e.response.data === "object" ? JSON.stringify(e.response.data) : e.response.data) : ''
             throw new Error('Authentication error (' + e.toString() + ') :: ' + customMessage)
         }
@@ -65,7 +73,7 @@ export class RetterSdk {
     static async getCloudObject(sdk: Retter, config: RetterCloudObjectConfig) {
         try {
             return await sdk.getCloudObject(config)
-        } catch (e) {
+        } catch (e: any) {
             let err = `Getting Cloud Object \n` + e.toString()
             if (e.response && e.response.data && e.response.data.message) {
                 err += '\n' + e.response.data.message
@@ -80,7 +88,7 @@ export class RetterSdk {
         try {
             const resp = await cloudObject.call<D>(params)
             return resp.data
-        } catch (e) {
+        } catch (e: any) {
             let err = `Calling Method \n` + e.toString()
             if (e.response && e.response.data && e.response.data.message) {
                 err += '\n' + e.response.data.message

--- a/src/lib/RetterSdk.ts
+++ b/src/lib/RetterSdk.ts
@@ -28,14 +28,12 @@ export class RetterSdk {
 
     static prepareRootUrlByKeyValue(classId: string, methodName: string, options: { key: string, value: string }, domain?: string) {
         let url
-        
-        if (domain) // GET URL FROM PROFILE
-        {
-            url = domain
-        }
-        else if (RIO_CLI_URL) { // GET URL FROM ENV
+    
+        if (RIO_CLI_URL) { 
             url = RIO_CLI_URL
-        } else { // GET DEFAULT URL
+        } else if (domain) {
+            url = domain
+        }else {
             url = RIO_CLI_ROOT_DOMAIN
             if (RIO_CLI_STAGE === 'PROD') {
                 url = `${RIO_CLI_ROOT_PROJECT_ID}.api.${url}`


### PR DESCRIPTION
1. domain section added to config (optional)

- `rio set-profile --profile-name TEST --secret-id SECRET_ID --secret-key SECRET_KEY --domain api.riotestv1.retter.io`

2. Unused recursive models support removed

3. Class Models support added 

- _projectPath/models + _projectPath/classes/**/models




