### PR TITLE
fix(v2): exclude .eslintcache and fix file-level exclusion

### DIFF
--- a/src/lib/v2/utils.ts
+++ b/src/lib/v2/utils.ts
@@ -4,7 +4,7 @@ import { FileInfo, V2ProjectConfig } from './types'
 import { PROJECT_RIO_CONFIG } from '../../config'
 
 const excludedFolders = ['__tests__', 'node_modules', 'scripts', '.turbo', '.nyc_output']
-const excludedFiles = ['.DS_Store', 'package-lock.json', 'yarn.lock']
+const excludedFiles = ['.DS_Store', 'package-lock.json', 'yarn.lock', '.eslintcache']
 
 export function listFilesRecursively(ogPath: string, directoryPath: string): { files: FileInfo[] } {
   const fileInfos: FileInfo[] = []
@@ -13,12 +13,15 @@ export function listFilesRecursively(ogPath: string, directoryPath: string): { f
     const fullPath = path.join(directoryPath, name)
     const stats = fs.statSync(fullPath)
     if (stats.isDirectory()) {
-      if (excludedFolders.includes(name) || excludedFiles.includes(name)) {
+      if (excludedFolders.includes(name)) {
         return
-      } 
-        const { files } = listFilesRecursively(ogPath, fullPath)
-        fileInfos.push(...files)  
+      }
+      const { files } = listFilesRecursively(ogPath, fullPath)
+      fileInfos.push(...files)
     } else {
+      if (excludedFiles.includes(name)) {
+        return
+      }
       const relativePath = path.relative(ogPath, fullPath)
       const fileName = relativePath.includes('/') ? relativePath : name
       fileInfos.push({ fileName, filePath: fullPath })


### PR DESCRIPTION
## Problem

In the v2 deploy path, `listFilesRecursively` (`src/lib/v2/utils.ts`) never applies `excludedFiles` to files. The check sits inside the `isDirectory()` branch:

```ts
if (stats.isDirectory()) {
  if (excludedFolders.includes(name) || excludedFiles.includes(name)) {
    return
  }
  ...
} else {
  // files pushed unconditionally — no exclusion check
}
```

So `excludedFiles` (`.DS_Store`, `package-lock.json`, `yarn.lock`) only ever matches a *directory* with that name, and individual files leak into deployments. This is also why `.rioignore` appears to have no effect for cache files in v2 — that path doesn't read `.rioignore` at all, and the hardcoded file list was dead code.

## Fix

- Move the `excludedFiles` check into the file (`else`) branch where it belongs.
- Keep `excludedFolders` in the directory branch.
- Add `.eslintcache` to `excludedFiles` (created per-package by `eslint --cache`).

Applies to both class file gathering and model file gathering (both use `listFilesRecursively`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)